### PR TITLE
Hotfix/runner shellexec

### DIFF
--- a/tests/Phrozn/Runner/CommandLine/Callback/BundleTest.php
+++ b/tests/Phrozn/Runner/CommandLine/Callback/BundleTest.php
@@ -465,7 +465,8 @@ class BundleTest
         }
         if (false === $justPurge) {
             $path = dirname($path);
-            `phr-dev init {$path}`;
+            $phrdev = dirname(dirname(dirname(dirname(dirname(__DIR__))))).'/bin/phrozn.php';
+            `{$phrdev} init {$path}`;
         }
     }
 }

--- a/tests/Phrozn/Runner/CommandLine/Callback/UpTest.php
+++ b/tests/Phrozn/Runner/CommandLine/Callback/UpTest.php
@@ -83,7 +83,11 @@ class UpTest
         $this->assertFalse(is_dir($path . '/.phrozn'));
         $this->assertFalse(is_dir($path . '/.phrozn/entries'));
         $this->assertFalse(is_readable($path . '/.phrozn/config.yml'));
-        `phr-dev init {$path}`;
+        
+        $phrdev = dirname(dirname(dirname(dirname(dirname(__DIR__))))).'/bin/phrozn.php';
+
+        `{$phrdev} init {$path}`;
+        
         $this->assertTrue(is_dir($path . '/.phrozn'));
         $this->assertTrue(is_dir($path . '/.phrozn/entries'));
         $this->assertTrue(is_readable($path . '/.phrozn/config.yml'));


### PR DESCRIPTION
I think that "phr-dev" would not work if it is not defined as shell's alias or user's environment path.
