### PR TITLE
View plugin overloading

### DIFF
--- a/Phrozn/Site/View/Factory.php
+++ b/Phrozn/Site/View/Factory.php
@@ -115,10 +115,10 @@ class Factory
      */
     private function constructFile($type)
     {
-        $class = 'Phrozn\\Site\\View\\' . ucfirst($type);
+        // try to see if we have user defined plugin
+        $class = 'PhroznPlugin\\Site\\View\\' . ucfirst($type);
         if (!class_exists($class)) {
-            // try to see if we have user defined plugin
-            $class = 'PhroznPlugin\\Site\\View\\' . ucfirst($type);
+            $class = 'Phrozn\\Site\\View\\' . ucfirst($type);
             if (!class_exists($class)) {
                 //throw new \Exception("View of type '{$type}' not found..");
                 $class = 'Phrozn\\Site\\View\\Plain';


### PR DESCRIPTION
Currently Phrozn checks if a builtin view is available and then falls back to a user plugin, this switches the processing order around allowing overloading of view classes.
