### PR TITLE
Issue #33 migrate to Console_Color2

### DIFF
--- a/Phrozn/Outputter/Console/Color.php
+++ b/Phrozn/Outputter/Console/Color.php
@@ -19,7 +19,7 @@
  */
 
 namespace Phrozn\Outputter\Console;
-use Console_Color as ConsoleColorer;
+use Console_Color2 as ConsoleColorer;
 
 /**
  * Due to wrong documentation Console_Color methods were used as static.

--- a/package.xml
+++ b/package.xml
@@ -447,9 +447,9 @@
     <min>1.1.3</min>
    </package>
    <package>
-    <name>Console_Color</name>
+    <name>Console_Color2</name>
     <channel>pear.php.net</channel>
-    <min>1.0.3</min>
+    <min>0.1.1</min>
    </package>
    <package>
     <name>Console_Table</name>


### PR DESCRIPTION
Hi Victor,

Migrating to `Console_Color2` is quite simple, I only change the name of class in the "outputter" section and fixed the required package into the pear package definition.

I try it out and all works correctly. I hope that this trivial task could be useful.

The main and active problem is that: Console_Color2 is in `alpha state` and for that reason when you try to install Phrozn with pear it stop the flow because of that. You have to install the dependency of Color_Console2 by hand and retry to install Phrozn.

```
pear install Console_Color2-alpha
pear install phrozn/Phrozn-beta
```

Thank you.

Walter
