### PR TITLE
Fixed use_ansi_colors option in all context (and add windows compatibility)

### DIFF
--- a/Phrozn/Outputter/DefaultOutputter.php
+++ b/Phrozn/Outputter/DefaultOutputter.php
@@ -32,6 +32,16 @@ class DefaultOutputter
     implements \Phrozn\Outputter
 {
     /**
+     * Whether to spice output with ANSI colors
+     */
+    private $useAnsiColors;
+
+    public function __construct($useAnsiColors = true)
+    {
+        $this->useAnsiColors = $useAnsiColors;
+    }
+
+    /**
      * Writes the message $msg to STDOUT.
      *
      * @param string $msg The message to output
@@ -42,6 +52,9 @@ class DefaultOutputter
     public function stdout($msg, $status = self::STATUS_OK)
     {
         $msg = Color::convert($status . $msg . "\n");
+        if ($this->useAnsiColors === false) {
+            $msg = Color::strip($msg);
+        }
         if (defined('STDOUT')) {
             fwrite(STDOUT, $msg);
         } else {
@@ -64,6 +77,9 @@ class DefaultOutputter
     public function stderr($msg, $status = self::STATUS_FAIL)
     {
         $msg = Color::convert($status . $msg . "\n");
+        if ($this->useAnsiColors === false) {
+            $msg = Color::strip($msg);
+        }
         if (defined('STDERR')) {
             fwrite(STDERR, $msg);
         } else {

--- a/Phrozn/Runner/CommandLine/Callback/Base.php
+++ b/Phrozn/Runner/CommandLine/Callback/Base.php
@@ -46,11 +46,6 @@ abstract class Base
     const STATUS_OK         = '  [%gOK%n]      ';
 
     /**
-     * Whether to spice output with ANSI colors
-     */
-    private $useAnsiColors;
-
-    /**
      * @var \Console_CommandLine_Outputter
      */
     private $outputter;
@@ -99,7 +94,10 @@ abstract class Base
     public function getOutputter()
     {
         if (null === $this->outputter) {
-            $this->outputter = new Outputter();
+            $config = $this->getConfig();
+            $meta = Yaml::load($config['paths']['configs'] . 'phrozn.yml');
+            $useAnsiColors = (bool)$meta['use_ansi_colors'];
+            $this->outputter = new Outputter($useAnsiColors);
         }
         return $this->outputter;
     }
@@ -159,10 +157,6 @@ abstract class Base
      */
     public function out($str)
     {
-        $str = Color::convert($str);
-        if ($this->useAnsiColors() === false) {
-            $str = Color::strip($str);
-        }
         $this->getOutputter()->stdout($str, '');
         if (count(\ob_get_status()) !== 0) {
             ob_flush();
@@ -350,16 +344,6 @@ abstract class Base
         }
 
         return $path;
-    }
-
-    private function useAnsiColors()
-    {
-        if (null === $this->useAnsiColors) {
-            $config = $this->getConfig();
-            $meta = Yaml::load($config['paths']['configs'] . 'phrozn.yml');
-            $this->useAnsiColors = (bool)$meta['use_ansi_colors'];
-        }
-        return $this->useAnsiColors;
     }
 
     private function getCommandMeta()

--- a/Phrozn/Runner/CommandLine/Callback/Clobber.php
+++ b/Phrozn/Runner/CommandLine/Callback/Clobber.php
@@ -75,11 +75,27 @@ class Clobber
         }
 
         if ($this->readLine() === 'yes') {
-            `rm -rf $path`;
+            $this->rrmdir($path);
             $this->out(self::STATUS_DELETED . " {$path}");
         } else {
             $this->out(self::STATUS_FAIL . " Aborted..");
         }
         $this->out($this->getFooter());
+    }
+
+    /**
+     * Recursively remove a directory
+     * @link http://php.net/manual/en/function.rmdir.php#108113
+     */
+    private function rrmdir($dir)
+    {
+        foreach(glob($dir . '/*') as $file) {
+            if (is_dir($file)) {
+                self::rrmdir($file);
+            } else {
+                unlink($file);
+            }
+        }
+        rmdir($dir);
     }
 }

--- a/Phrozn/Site/View/Base.php
+++ b/Phrozn/Site/View/Base.php
@@ -463,10 +463,11 @@ abstract class Base
         $layoutName = $this->getParam('page.layout', ViewFactory::DEFAULT_LAYOUT_SCRIPT);
 
         $inputFile = $this->getInputFile();
-        $pos = strpos($inputFile, '/entries');
+        $ds  = DIRECTORY_SEPARATOR;
+        $pos = strpos($inputFile, $ds . 'entries');
         // make sure that input path is normalized to root entries directory
         if (false !== $pos) {
-            $inputFile = substr($inputFile, 0, $pos + 8) . '/entry';
+            $inputFile = substr($inputFile, 0, $pos + 8) . $ds . 'entry';
         }
         $layoutPath = realpath(dirname($inputFile) . '/../layouts/' . $layoutName);
 

--- a/bin/phr.bat
+++ b/bin/phr.bat
@@ -20,4 +20,4 @@ GOTO RUN
 :USE_PEAR_PATH
 set PHPBIN=%PHP_PEAR_PHP_BIN%
 :RUN
-"%PHPBIN%" "@bin_dir@\phr" %*
+"%PHPBIN%" "@bin_dir@\phrozn" %*

--- a/build/build.php
+++ b/build/build.php
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 use Phrozn\Autoloader as Loader;
-error_reporting(E_ALL & ~E_NOTICE);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
 // rely on configuration files
 require_once dirname(__FILE__) . '/../Phrozn/Autoloader.php';
@@ -34,6 +34,7 @@ $e = $pack->setOptions(array(
         'tests'     => 'test',
     ),
     'exceptions' => array(
+        'bin/phr.bat' => 'script',
         'bin/phrozn.php' => 'script',
         'bin/phr.php' => 'script',
         'LICENSE' => 'doc',
@@ -64,6 +65,12 @@ $pack->setLicense('Apache License, Version 2.0', 'http://www.apache.org/licenses
 $pack->addMaintainer('lead', 'victor', 'Victor Farazdagi', 'simple.square@gmail.com');
 
 $pack->addRelease();
+$pack->setOSInstallCondition('windows');
+$pack->addInstallAs('bin/phr.bat', 'phrozn.bat');
+$pack->addInstallAs('bin/phrozn.php', 'phrozn');
+
+$pack->addRelease();
+$pack->addIgnoreToRelease('bin/phr.bat');
 $pack->addInstallAs('bin/phr.php', 'phr');
 $pack->addInstallAs('bin/phrozn.php', 'phrozn');
 
@@ -81,6 +88,9 @@ $pack->addReplacement('bin/phrozn.php', 'pear-config', '/usr/bin/env php', 'php_
 $pack->addReplacement('bin/phrozn.php', 'pear-config', '@PHP-BIN@', 'php_bin');
 $pack->addReplacement('bin/phrozn.php', 'pear-config', '@DATA-DIR@', 'data_dir');
 $pack->addReplacement('bin/phrozn.php', 'pear-config', '@PEAR-DIR@', 'php_dir');
+
+$pack->addReplacement('bin/phr.bat', 'pear-config', '@php_bin@', 'php_bin');
+$pack->addReplacement('bin/phr.bat', 'pear-config', '@bin_dir@', 'bin_dir');
 
 $pack->addReplacement('bin/phr.php', 'pear-config', '/usr/bin/env php', 'php_bin');
 $pack->addReplacement('bin/phr.php', 'pear-config', '@PHP-BIN@', 'php_bin');


### PR DESCRIPTION
Hello,

I've begun to play with Phrozen 0.4.1 few days ago, and while I like to appreciate features, I was sad to see windows incompatibility.

It's not really a problem, and I can contribute to add such compatibility.

First we can consider to fix the issue about configuration option use_ansi_colors that did not work in all context.

On Windows, ANSI color code are not supported. So I've tried to switch off the option in %data_dir%\Phrozn\configs\phrozn.yml

```
use_ansi_colors: false
```

But, if it's solve the _help_ and _init_ command, it did not solve the _up_ command

Current output 

```
Phrozn 0.4.1 by Victor Farazdagi

Starting static site compilation.

  [OK]      Source directory located: D:\Phrozen_dest_dir/.phrozn/
  [OK]      Destination directory located: D:\Phrozen_dest_dir/
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir\.phrozn\entries\about.twig←[0m parsed
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir/about/index.html←[0m written
  [←[31mFAIL←[0m]    D:\Phrozen_dest_dir\.phrozn\entries\demos\modal.twig: View source file cannot be read:
  [←[31mFAIL←[0m]    D:\Phrozen_dest_dir\.phrozn\entries\demos\popup.twig: View source file cannot be read:
  [←[31mFAIL←[0m]    D:\Phrozen_dest_dir\.phrozn\entries\demos\tabs.twig: View source file cannot be read:
  [←[31mFAIL←[0m]    D:\Phrozen_dest_dir\.phrozn\entries\demos\twipsy.twig: View source file cannot be read:
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir\.phrozn\entries\index.twig←[0m parsed
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir/index.html←[0m written
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir\.phrozn\styles\bootstrap.less←[0m parsed
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir/styles/bootstrap.css←[0m written
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir\.phrozn\styles\default.less←[0m parsed
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir/styles/default.css←[0m written
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir\.phrozn\scripts\default.js←[0m parsed
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir/scripts/default.js←[0m written
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir\media\img\README←[0m copied
  [←[32mOK←[0m]      ←[34mD:\Phrozen_dest_dir\media\README←[0m copied

Phrozn is extremely flexible static site generator for PHP.
For additional information, see http://phrozn.info
```

And expected output 

```
Phrozn 0.4.1 by Victor Farazdagi

Starting static site compilation.

  [OK]      Source directory located: D:\Phrozen_dest_dir/.phrozn/
  [OK]      Destination directory located: D:\Phrozen_dest_dir/
  [OK]      D:\Phrozen_dest_dir\.phrozn\entries\about.twig parsed
  [OK]      D:\Phrozen_dest_dir/about/index.html written
  [FAIL]    D:\Phrozen_dest_dir\.phrozn\entries\demos\modal.twig: View source file cannot be read:
  [FAIL]    D:\Phrozen_dest_dir\.phrozn\entries\demos\popup.twig: View source file cannot be read:
  [FAIL]    D:\Phrozen_dest_dir\.phrozn\entries\demos\tabs.twig: View source file cannot be read:
  [FAIL]    D:\Phrozen_dest_dir\.phrozn\entries\demos\twipsy.twig: View source file cannot be read:
  [OK]      D:\Phrozen_dest_dir\.phrozn\entries\index.twig parsed
  [OK]      D:\Phrozen_dest_dir/index.html written
  [OK]      D:\Phrozen_dest_dir\.phrozn\styles\bootstrap.less parsed
  [OK]      D:\Phrozen_dest_dir/styles/bootstrap.css written
  [OK]      D:\Phrozen_dest_dir\.phrozn\styles\default.less parsed
  [OK]      D:\Phrozen_dest_dir/styles/default.css written
  [OK]      D:\Phrozen_dest_dir\.phrozn\scripts\default.js parsed
  [OK]      D:\Phrozen_dest_dir/scripts/default.js written
  [OK]      D:\Phrozen_dest_dir\media\img\README copied
  [OK]      D:\Phrozen_dest_dir\media\README copied

Phrozn is extremely flexible static site generator for PHP.
For additional information, see http://phrozn.info
```

My solution is provided by this pull request
