### PR TITLE
Front matter split fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __TwigTemplate*
 /build/pear/*
 /tests/code-coverage
+/tests/Phrozn/Bundle/project/.phrozn
 .settings
 .buildpath
 .project
+phr-dev

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,7 +8,7 @@ Names should be added to this file like so:
 Please keep the list sorted.
 
 Chris Smith
-Jonathan Van Belle 
+Jonathan Van Belle <grummfy@gmail.com>
 Kazusuke Sasezaki
 Osman Üngür <osmanungur@gmail.com>
 Ralph Schindler

--- a/Phrozn/Site/View/Base.php
+++ b/Phrozn/Site/View/Base.php
@@ -484,7 +484,7 @@ abstract class Base
         $layout = $factory->create(); // essentially layout is Site\View as well
         $layout->hasLayout(false); // no nested layouts
 
-        return $layout->render(array('content' => $content, 'entry' => $vars['page']));
+        return $layout->render(array('content' => $content, 'entry' => $vars['page'], 'current' => $vars['current']));
     }
 
     /**
@@ -516,7 +516,7 @@ abstract class Base
 
         $source = $this->readSourceFile();
 
-        $parts = preg_split('/[\n]*[-]{3}[\n]/', $source, 2);
+        $parts = preg_split('/([\n\r]{1})---([\n\r])/', $source, 2);
         if (count($parts) === 2) {
             $this->frontMatter = Yaml::load($parts[0]);
             $this->template = trim($parts[1]);


### PR DESCRIPTION
If entry file contains something like this

> abc
> abc
> abc
> ---
> 
> def
> It will be splitted like this
> _frontMatter_
> abc
> abc
> abc
> _content_
> def
> but it shouldn't

With this fix everythiong work like we want ....
