### PR TITLE
Fix truncated extension using Plain strategy

### DIFF
--- a/Phrozn/Site/View/OutputPath/Plain.php
+++ b/Phrozn/Site/View/OutputPath/Plain.php
@@ -52,6 +52,7 @@ class Plain
         }
 
         $object = new $class($this->getView());
-        return rtrim($object->get(), '.html');
+        return preg_replace("/\.html?/", "", $object->get());
+
     }
 }


### PR DESCRIPTION
The actual `Phrozn/Site/View/OutputPath/Plain.php` uses `rtrim` to remove the file extensions.

The problem is that if you configure a permalink like `test.xml` the output is `test.x` because of `rtrim` (similar to `test.txt` becomes `test.tx`. Using of `preg_replace` fix this bug.

I hope that is useful.

Walter
