### PR TITLE
Use permalink if exists instead append .html

### DIFF
--- a/Phrozn/Site/View/OutputPath/Entry/Parametrized.php
+++ b/Phrozn/Site/View/OutputPath/Entry/Parametrized.php
@@ -40,6 +40,7 @@ class Parametrized
     {
         $path = $this->getView()->getParam('this.permalink');
         $params = $this->getView()->getParams();
+        $permalink = $this->getView()->getParam('this.permalink', null);
 
         $params = array_merge($params['site'], $params['page']);
         foreach ($params as $name => $param) {
@@ -54,7 +55,7 @@ class Parametrized
 
         if (substr($path, -1) === '/') {
             $path .= 'index.html';
-        } else if (substr($path, -5) !== '.html') {
+        } else if (is_null($permalink) && substr($path, -5) !== '.html') {
             $path .= '.html';
         }
 

--- a/tests/Phrozn/Site/project/.phrozn/entries/compile-permalink-parametrized.twig
+++ b/tests/Phrozn/Site/project/.phrozn/entries/compile-permalink-parametrized.twig
@@ -1,6 +1,6 @@
 layout: default.twig
 title: Testing permalink generation
-permalink: /2011/03/17/:title
+permalink: /2011/03/17/:title.html
 ---
 {% for letter in 'a'..'h' %}{{ letter }}{% endfor %} 
 


### PR DESCRIPTION
Hi mates,

just another PR. Actually the compilation process when someone put a `permalink` strategy the `.html` is appended by default. This trend could be a problem if I need to create particular pages for eg: `permalink: /installer` that is a script file.

I think that if place a permalink Phrozn has to use my permalink and not append `.html`, of course if I create a permalink as `/create/this/path/` the result is `/create/this/path/index.html` 

What do you think about this?

Bye
