### PR TITLE
Updated site compilation to respect exact paths for files.

### DIFF
--- a/Phrozn/Site/Base.php
+++ b/Phrozn/Site/Base.php
@@ -238,6 +238,7 @@ abstract class Base
                 if ($item->isFile()) {
                     try {
                         $factory = new View\Factory($item->getRealPath());
+                        $factory->setInputRootDir($projectDir);
                         $view = $factory->create();
                         $view
                             ->setSiteConfig($this->getSiteConfig())
@@ -270,6 +271,7 @@ abstract class Base
         if (!is_dir($dir . '/entries')) {
             throw new \RuntimeException('Entries folder not found');
         }
+
         return $dir;
     }
 

--- a/Phrozn/Site/DefaultSite.php
+++ b/Phrozn/Site/DefaultSite.php
@@ -87,11 +87,21 @@ class DefaultSite
     {
         $projectDir = $this->getProjectDir();
         $outputDir = $this->getOutputDir();
+        $config = $this->getSiteConfig();
+
+        // configure skip files options
+        $skipToken = '-!SKIP!-';
 
         $dir = new \RecursiveDirectoryIterator($projectDir . '/media');
         $it = new \RecursiveIteratorIterator($dir, \RecursiveIteratorIterator::SELF_FIRST);
         foreach ($it as $item) {
             $baseName = $item->getBaseName();
+            if (isset($config['skip'])) {
+                $baseName = preg_replace($config['skip'], array_fill(0, count($config['skip']), $skipToken), $baseName);
+                if (strpos($baseName, $skipToken) !== false) {
+                    continue;
+                }
+            }
             if ($item->isFile()) {
                 $inputFile = $item->getRealPath();
 

--- a/Phrozn/Site/View/Base.php
+++ b/Phrozn/Site/View/Base.php
@@ -38,6 +38,12 @@ abstract class Base
     implements \Phrozn\Site\View
 {
     /**
+     * Input root dir
+     * @var string
+     */
+    private $inputRootDir;
+
+    /**
      * Input file path
      * @var string
      */
@@ -53,7 +59,7 @@ abstract class Base
      * Output file path
      * @var string
      */
-    private $outputFile;
+    protected $outputFile;
 
     /**
      * Registered text processors
@@ -122,12 +128,12 @@ abstract class Base
     {
         $out = $this->render($vars);
 
-        $destinationDir = dirname($this->getOutputFile());
+        $outputFile = $this->getOutputFile();
+        $destinationDir = dirname($outputFile);
         if (!is_dir($destinationDir)) {
             mkdir($destinationDir, 0777, true);
         }
 
-        $outputFile = $this->getOutputFile();
         if (!is_dir($outputFile)) {
             file_put_contents($outputFile, $out);
         } else {
@@ -219,8 +225,35 @@ abstract class Base
      */
     public function getOutputFile()
     {
-        $path = new OutputFile($this);
-        return $path->get();
+        if (!$this->outputFile) {
+            $path = new OutputFile($this);
+            $this->setOutputFile($path->get());
+        }
+
+        return $this->outputFile;
+    }
+
+    /**
+     * Set input root directory path
+     *
+     * @param string $path Directory path
+     *
+     * @return \Phrozn\Site\View
+     */
+    public function setInputRootDir($path)
+    {
+        $this->inputRootDir = $path;
+        return $this;
+    }
+
+    /**
+     * Get input root directory path
+     *
+     * @return string
+     */
+    public function getInputRootDir()
+    {
+        return $this->inputRootDir;
     }
 
     /**

--- a/Phrozn/Site/View/Css.php
+++ b/Phrozn/Site/View/Css.php
@@ -56,7 +56,11 @@ class Css
      */
     public function getOutputFile()
     {
-        $path = new OutputFile($this);
-        return $path->get();
+        if (!$this->outputFile) {
+            $path = new OutputFile($this);
+            $this->setOutputFile($path->get());
+        }
+
+        return $this->outputFile;
     }
 }

--- a/Phrozn/Site/View/Factory.php
+++ b/Phrozn/Site/View/Factory.php
@@ -43,6 +43,13 @@ class Factory
     const DEFAULT_LAYOUT_SCRIPT = 'default.twig';
 
     /**
+     * Path to input root dir
+     *
+     * @var string
+     */
+    private $inputRootDir;
+
+    /**
      * Path to input file
      * @var string
      */
@@ -72,6 +79,29 @@ class Factory
         $type = $ext ? : self::DEFAULT_VIEW_TYPE;
 
         return $this->constructFile($type);
+    }
+
+    /**
+     * Set input root dir
+     *
+     * @param string $path Input root directory
+     *
+     * @return \Phrozn\Site\View\Factory
+     */
+    public function setInputRootDir($path)
+    {
+        $this->inputRootDir = $path;
+        return $this;
+    }
+
+    /**
+     * Get input root directory
+     *
+     * @return string
+     */
+    public function getInputRootDir()
+    {
+        return $this->inputRootDir;
     }
 
     /**
@@ -122,6 +152,7 @@ class Factory
             }
         }
         $object = new $class;
+        $object->setInputRootDir($this->getInputRootDir());
         $object->setInputFile($this->getInputFile());
         return $object;
     }

--- a/Phrozn/Site/View/Js.php
+++ b/Phrozn/Site/View/Js.php
@@ -56,8 +56,12 @@ class Js
      */
     public function getOutputFile()
     {
-        $path = new OutputFile($this);
-        return $path->get();
+        if (!$this->outputFile) {
+            $path = new OutputFile($this);
+            $this->setOutputFile($path->get());
+        }
+
+        return $this->outputFile;
     }
 
 }

--- a/Phrozn/Site/View/Less.php
+++ b/Phrozn/Site/View/Less.php
@@ -56,8 +56,12 @@ class Less
      */
     public function getOutputFile()
     {
-        $path = new OutputFile($this);
-        return $path->get();
+        if (!$this->outputFile) {
+            $path = new OutputFile($this);
+            $this->setOutputFile($path->get());
+        }
+
+        return $this->outputFile;
     }
 
 }

--- a/Phrozn/Site/View/Markdown.php
+++ b/Phrozn/Site/View/Markdown.php
@@ -74,7 +74,11 @@ class Markdown
      */
     public function getOutputFile()
     {
-        $path = new OutputFile($this);
-        return $path->get();
+        if (!$this->outputFile) {
+            $path = new OutputFile($this);
+            $this->setOutputFile($path->get());
+        }
+
+        return $this->outputFile;
     }
 }

--- a/Phrozn/Site/View/OutputPath/Base.php
+++ b/Phrozn/Site/View/OutputPath/Base.php
@@ -80,9 +80,26 @@ abstract class Base
     protected function getInputFileWithoutExt()
     {
         $info = pathinfo($this->getView()->getInputFile());
+
         return $info['dirname']
             . DIRECTORY_SEPARATOR
             . ($info['filename']?:$info['basename']); // allow dot files
+    }
+
+    /**
+     * Get the file extension for the input file
+     *
+     * @return string
+     */
+    protected function getInputFileExtension($includeDot = true)
+    {
+        $extension = pathinfo($this->getView()->getInputFile(), PATHINFO_EXTENSION);
+
+        if ($includeDot && $extension != '') {
+            return '.' . $extension;
+        }
+
+        return $extension;
     }
 
     /**
@@ -93,17 +110,21 @@ abstract class Base
      *
      * @return string
      */
-    protected function getRelativeFile($base, $prepend = true)
+    protected function getRelativeFile($base = '', $prepend = true)
     {
         // find file path w/o extension
         $inputFile = $this->getInputFileWithoutExt();
+        $inputRoot = $this->getView()->getInputRootDir();
 
-        // find relative path, wrt to scripts
-        $pos = strpos($inputFile, '/' . $base);
-        if ($pos !== false) {
-            $inputFile = substr($inputFile, $pos + ($prepend ? 0 : 1 + strlen($base)));
-        } else {
-            $inputFile = ($prepend ? '/' . $base : ''). '/' . basename($inputFile);
+        // Remove the input root from the input filename
+        $inputFile = str_replace($inputRoot, '', $inputFile);
+
+        // find relative path, wrt to output root dir
+        if ($base) {
+            $pos = strpos($inputFile, $base);
+            if ($pos !== false) {
+                $inputFile = substr($inputFile, $pos + ($prepend ? 0 : 1 + strlen($base)));
+            }
         }
 
         return $inputFile;

--- a/Phrozn/Site/View/OutputPath/Plain.php
+++ b/Phrozn/Site/View/OutputPath/Plain.php
@@ -43,7 +43,8 @@ class Plain
         if ($permalink === null) {
             return rtrim($this->getView()->getOutputDir(), '/')
                 . '/'
-                . ltrim($this->getRelativeFile('entries', false), '/');
+                . ltrim($this->getRelativeFile('entries', false), '/')
+                . $this->getInputFileExtension();
         }
 
         $class = 'Phrozn\\Site\\View\\OutputPath\\Entry\\' . ucfirst($permalink);

--- a/Phrozn/Site/View/OutputPath/Script.php
+++ b/Phrozn/Site/View/OutputPath/Script.php
@@ -40,6 +40,6 @@ class Script
     {
         return rtrim($this->getView()->getOutputDir(), '/')
              . '/'
-             . ltrim($this->getRelativeFile('scripts'), '/') . '.js';
+             . ltrim($this->getRelativeFile(), '/') . '.js';
     }
 }

--- a/Phrozn/Site/View/OutputPath/Style.php
+++ b/Phrozn/Site/View/OutputPath/Style.php
@@ -40,6 +40,6 @@ class Style
     {
         return rtrim($this->getView()->getOutputDir(), '/')
              . '/'
-             . ltrim($this->getRelativeFile('styles'), '/') . '.css';
+             . ltrim($this->getRelativeFile(), '/') . '.css';
     }
 }

--- a/Phrozn/Site/View/Plain.php
+++ b/Phrozn/Site/View/Plain.php
@@ -68,7 +68,11 @@ class Plain
      */
     public function getOutputFile()
     {
-        $path = new OutputFile($this);
-        return $path->get();
+        if (!$this->outputFile) {
+            $path = new OutputFile($this);
+            $this->setOutputFile($path->get());
+        }
+
+        return $this->outputFile;
     }
 }

--- a/Phrozn/Site/View/Textile.php
+++ b/Phrozn/Site/View/Textile.php
@@ -74,7 +74,11 @@ class Textile
      */
     public function getOutputFile()
     {
-        $path = new OutputFile($this);
-        return $path->get();
+        if (!$this->outputFile) {
+            $path = new OutputFile($this);
+            $this->setOutputFile($path->get());
+        }
+
+        return $this->outputFile;
     }
 }

--- a/Phrozn/Site/View/Twig.php
+++ b/Phrozn/Site/View/Twig.php
@@ -103,7 +103,11 @@ class Twig
      */
     public function getOutputFile()
     {
-        $path = new OutputFile($this);
-        return $path->get();
+        if (!$this->outputFile) {
+            $path = new OutputFile($this);
+            $this->setOutputFile($path->get());
+        }
+
+        return $this->outputFile;
     }
 }

--- a/tests/Phrozn/Site/DefaultSiteTest.php
+++ b/tests/Phrozn/Site/DefaultSiteTest.php
@@ -101,7 +101,7 @@ class DefaultSiteTest
         $this->assertTrue(is_readable($path . 'site/2011-02-24-default-site.html'));
         $this->assertTrue(is_readable($path . 'site/2011-02-21-phrozn-generated-first-page-today.html'));
 
-        $outputter->assertInLogs("2011-02-24-wrong-file-type written");
+        $outputter->assertInLogs("2011-02-24-wrong-file-type.wrong written");
         $outputter->assertInLogs("2011-02-21-phrozn-generated-first-page-today.twig parsed");
         $outputter->assertInLogs("2011-02-24-default-site.twig parsed");
 
@@ -126,11 +126,12 @@ class DefaultSiteTest
         $site
             ->setOutputter($outputter)
             ->compile();
+
         $this->assertTrue(is_readable($path . 'site/2011-02-24-default-site.html'));
         $this->assertTrue(is_readable($path . 'site/2011-02-21-phrozn-generated-first-page-today.html'));
         $this->assertTrue(is_readable($path . 'site/media/img/test.png'));
 
-        $outputter->assertInLogs("2011-02-24-wrong-file-type written");
+        $outputter->assertInLogs("2011-02-24-wrong-file-type.wrong written");
         $outputter->assertInLogs("2011-02-21-phrozn-generated-first-page-today.twig parsed");
         $outputter->assertInLogs("2011-02-24-default-site.twig parsed");
 

--- a/tests/Phrozn/Site/View/CssTest.php
+++ b/tests/Phrozn/Site/View/CssTest.php
@@ -57,6 +57,7 @@ class CssTest
         $css = dirname(__FILE__) . '/styles/style.css';
         $path = dirname(__FILE__) . '/out';
         $view = new View($css, $path);
+        $view->setInputRootDir(dirname(__FILE__));
 
         $this->assertSame('style.css', basename($view->getInputFile()));
         $this->assertSame('style.css', basename($view->getOutputFile()));

--- a/tests/Phrozn/Site/View/JsTest.php
+++ b/tests/Phrozn/Site/View/JsTest.php
@@ -59,6 +59,7 @@ class JsTest
         $jsOut = dirname(__FILE__) . '/scripts/jquery/test.js';
         $path = dirname(__FILE__) . '/out';
         $view = new View($jsIn, $path);
+        $view->setInputRootDir(dirname(__FILE__));
 
         $this->assertSame('test.js', basename($view->getInputFile()));
         $this->assertSame('test.js', basename($view->getOutputFile()));

--- a/tests/Phrozn/Site/View/LessTest.php
+++ b/tests/Phrozn/Site/View/LessTest.php
@@ -59,6 +59,7 @@ class LessTest
         $css = dirname(__FILE__) . '/styles/style.css';
         $path = dirname(__FILE__) . '/out';
         $view = new View($less, $path);
+        $view->setInputRootDir(dirname(__FILE__));
 
         $this->assertSame('style.less', basename($view->getInputFile()));
         $this->assertSame('style.css', basename($view->getOutputFile()));

--- a/tests/Phrozn/Site/View/MarkdownTest.php
+++ b/tests/Phrozn/Site/View/MarkdownTest.php
@@ -59,6 +59,7 @@ class MarkdownTest
         $html = dirname(__FILE__) . '/../project/.phrozn/entries/markdown.html';
         $path = dirname(__FILE__) . '/out/';
         $view = new View($entry, $path);
+        $view->setInputRootDir(dirname(__FILE__) . '/..project/.phrozn');
 
         $this->assertSame('markdown.markdown', basename($view->getInputFile()));
         $this->assertSame('markdown.html', basename($view->getOutputFile()));

--- a/tests/Phrozn/Site/View/OutputPathTest.php
+++ b/tests/Phrozn/Site/View/OutputPathTest.php
@@ -27,7 +27,7 @@ use Phrozn\Site\View\OutputPath,
  * @package     Phrozn\Site
  * @author      Victor Farazdagi
  */
-class OuputPathTest
+class OutputPathTest
     extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
@@ -36,6 +36,8 @@ class OuputPathTest
     public function testEntriesPaths()
     {
         $view = new View\Twig();
+        $view->setInputRootDir('/var/www/phrozn-test/');
+
         $view
             ->setInputFile('/var/www/phrozn-test/entries/some-entry.twig')
             ->setOutputDir('/var/www/output');
@@ -52,12 +54,14 @@ class OuputPathTest
             ->setInputFile('/var/www/phrozn-test/sub/folder/some-entry.twig')
             ->setOutputDir('/var/www/output');
         $path->setView($view);
-        $this->assertSame('/var/www/output/some-entry.html', $path->get());
+        $this->assertSame('/var/www/output/sub/folder/some-entry.html', $path->get());
     }
 
     public function testStylesPaths()
     {
         $view = new View\Less();
+        $view->setInputRootDir('/var/www/phrozn-test/');
+
         $view
             ->setInputFile('/var/www/phrozn-test/styles/some-entry.less')
             ->setOutputDir('/var/www/output');
@@ -74,12 +78,14 @@ class OuputPathTest
             ->setInputFile('/var/www/phrozn-test/sub/folder/some-entry.less')
             ->setOutputDir('/var/www/output');
         $path->setView($view);
-        $this->assertSame('/var/www/output/styles/some-entry.css', $path->get());
+        $this->assertSame('/var/www/output/sub/folder/some-entry.css', $path->get());
     }
 
     public function testScriptsPaths()
     {
         $view = new View\Less();
+        $view->setInputRootDir('/var/www/phrozn-test/');
+
         $view
             ->setInputFile('/var/www/phrozn-test/scripts/some-entry.js')
             ->setOutputDir('/var/www/output');
@@ -96,7 +102,7 @@ class OuputPathTest
             ->setInputFile('/var/www/phrozn-test/sub/folder/some-entry.js')
             ->setOutputDir('/var/www/output');
         $path->setView($view);
-        $this->assertSame('/var/www/output/scripts/some-entry.js', $path->get());
+        $this->assertSame('/var/www/output/sub/folder/some-entry.js', $path->get());
     }
 
 }

--- a/tests/Phrozn/Site/View/PlainTest.php
+++ b/tests/Phrozn/Site/View/PlainTest.php
@@ -57,6 +57,7 @@ class PlainTest
         $content = dirname(__FILE__) . '/entries/htaccess';
         $path = dirname(__FILE__) . '/out';
         $view = new View($content, $path);
+        $view->setInputRootDir(dirname(__FILE__));
 
         $this->assertSame('htaccess', basename($view->getInputFile()));
         $this->assertSame('.htaccess', basename($view->getOutputFile()));

--- a/tests/Phrozn/Site/View/TextileTest.php
+++ b/tests/Phrozn/Site/View/TextileTest.php
@@ -60,6 +60,7 @@ class TextileTest
         $html = dirname(__FILE__) . '/../project/.phrozn/entries/textile.html';
         $path = dirname(__FILE__) . '/out/';
         $view = new View($entry, $path);
+        $view->setInputRootDir(dirname(__FILE__));
 
         $this->assertSame('textile.textile', basename($view->getInputFile()));
         $this->assertSame('textile.html', basename($view->getOutputFile()));

--- a/tests/Phrozn/Site/View/TwigTest.php
+++ b/tests/Phrozn/Site/View/TwigTest.php
@@ -75,6 +75,7 @@ class TwigTest
         $html = dirname(__FILE__) . '/../project/.phrozn/entries/2011-02-24-compile.html';
         $path = dirname(__FILE__) . '/out/';
         $view = new View($twig, $path);
+        $view->setInputRootDir(dirname(__FILE__) . '/../project/.phrozn');
 
         $this->assertSame('2011-02-24-compile.twig', basename($view->getInputFile()));
         $this->assertSame('2011-02-24-compile.html', basename($view->getOutputFile()));


### PR DESCRIPTION
This fixes one part of issue #20, where the scripts/README file was ending up in root/README instead of root/scripts/README. The other problem in issue #20 is not re-createable at the current version (0.5.3DEV).

Added root input dir to view object to better handle exact paths of files to be
processed and moved during site compilation.

Optimized site view objects to cache the calculated output path so it doesn't
have to recalculate it each time it is called.
