### PR TITLE
Manage LESS @import directive

### DIFF
--- a/Phrozn/Processor/Less.php
+++ b/Phrozn/Processor/Less.php
@@ -39,6 +39,13 @@ class Less
     protected $lessc;
 
     /**
+     * The path where the LESS compiler will search for @import directives
+     *
+     * @var string
+     */
+    protected $lessImportDir;
+
+    /**
      * If configuration options are passes then twig environment
      * is initialized right away
      *
@@ -58,6 +65,16 @@ class Less
     }
 
     /**
+     * Store the input file if given
+     *
+     * @param $options
+     */
+    public function setLessImportDir($lessImportDir)
+    {
+        $this->lessImportDir = $lessImportDir;
+    }
+
+    /**
      * Parse the incoming template
      *
      * @param string $tpl Source template content
@@ -71,10 +88,16 @@ class Less
                     ->parse($tpl);
     }
 
+    /**
+     * Get LESS compiler (if undefined, set it with path for @import directives)
+     *
+     * @param boolean $reset
+     */
     protected function getEnvironment($reset = false)
     {
         if ($reset === true || null === $this->lessc) {
             $this->lessc = new \lessc;
+            $this->lessc->importDir = $this->lessImportDir;
         }
 
         return $this->lessc;

--- a/Phrozn/Site/View/Less.php
+++ b/Phrozn/Site/View/Less.php
@@ -50,6 +50,22 @@ class Less
     }
 
     /**
+     * Set the input file into processors configuration
+     *
+     * @param $inputFile
+     */
+    public function setInputFile($inputFile)
+    {
+        if (null !== $processors = $this->getProcessors()) {
+            foreach ($processors as $processor) {
+                $processor->setLessImportDir(dirname($inputFile));
+            }
+        }
+
+        return parent::setInputFile($inputFile);
+    }
+
+    /**
      * Get output file path
      *
      * @return string

--- a/tests/Phrozn/Processor/LessTest.php
+++ b/tests/Phrozn/Processor/LessTest.php
@@ -51,4 +51,16 @@ class LessTest
         $this->assertSame($processor->getConfig(), $configSample);
     }
 
+    public function testRenderImportLessDirective()
+    {
+        $tpl = file_get_contents($this->path . 'tpl2.less');
+        $expectedResult = file_get_contents($this->path . 'tpl1.css');
+
+        $processor = new Processor();
+        $processor->setLessImportDir($this->path);
+
+        $rendered = $processor->render($tpl);
+        $this->assertSame($rendered, $expectedResult);
+    }
+
 }

--- a/tests/Phrozn/Processor/templates/tpl2.less
+++ b/tests/Phrozn/Processor/templates/tpl2.less
@@ -1,0 +1,1 @@
+@import "tpl1.less";


### PR DESCRIPTION
There is a bug while trying to use LESS @import directive, because lessphp doesn't know where to search imported less files.

This PR fixes it by setting the lessphp importDir from the dirname of the current less file.

It is unit-tested
