### PR TITLE
Made Phrozn\View\Base::has_layout public

### DIFF
--- a/Phrozn/Site/View/Base.php
+++ b/Phrozn/Site/View/Base.php
@@ -529,7 +529,7 @@ abstract class Base
      *
      * @return boolean
      */
-    protected function hasLayout($value = null)
+    public function hasLayout($value = null)
     {
         if (null !== $value) {
             $this->hasLayout = $value;


### PR DESCRIPTION
I would like the `has_layout` method to be public for the following use case: I'm developing an EntryList plugin - a custom provider that reads all the entries in a directory and generates teasers from them (for a more blog-like structure with list->detail pages). And I'd like to re-use the existing view classes to be able to generate teasers from any format that Phrozn can parse. But many view types render the entries with a layout, which messes up the HTML of the teaser list. 

Is there any special reason why had_layout is protected? 
Or maybe you have other suggestions on how to solve my use case?
