### PR TITLE
Allow for compilation outside the root

### DIFF
--- a/skeleton/layouts/default.twig
+++ b/skeleton/layouts/default.twig
@@ -40,10 +40,10 @@
         </script>
     </head>
     <body>
-        {% include 'layouts/topbar.twig'%}
+        {% include './topbar.twig'%}
         <div class="container">
             {{ content }}
-            {% include 'layouts/footer.twig'%}
+            {% include './footer.twig'%}
         </div>
     </body>
 </html>


### PR DESCRIPTION
This addresses issue number 90 that I just filled.

This allows the default twig to successfully compile the demo site with the
following command:

phr up src public_html

(it does not address the bootstrap 1.4.0 issue)
