### PR TITLE
Making it work on Windows

### DIFF
--- a/Phrozn/Runner/CommandLine/Callback/Base.php
+++ b/Phrozn/Runner/CommandLine/Callback/Base.php
@@ -350,7 +350,7 @@ abstract class Base
     protected function isAbsolute($path)
     {
         if (PHP_OS == 'WINNT' || PHP_OS == 'WIN32') {
-            $pattern = '/^[a-zA-z]:.*[^.lnk]$/';
+            $pattern = '/^[a-zA-Z]:[\\\\\/]/';
             return preg_match($pattern, $path);
         } else {
             return $path{0} == '/';

--- a/Phrozn/Site/View/Base.php
+++ b/Phrozn/Site/View/Base.php
@@ -505,6 +505,8 @@ abstract class Base
         $layoutName = $this->getParam('page.layout', ViewFactory::DEFAULT_LAYOUT_SCRIPT);
 
         $inputFile = $this->getInputFile();
+        $inputFile = str_replace('\\', '/', $inputFile);
+
         $pos = strpos($inputFile, '/entries');
         // make sure that input path is normalized to root entries directory
         if (false !== $pos) {

--- a/Phrozn/Site/View/OutputPath/Base.php
+++ b/Phrozn/Site/View/OutputPath/Base.php
@@ -116,6 +116,14 @@ abstract class Base
         $inputFile = $this->getInputFileWithoutExt();
         $inputRoot = $this->getView()->getInputRootDir();
 
+        // Normalize direcotry separators so comparison works
+        $trans = array(
+            '/' => DIRECTORY_SEPARATOR,
+            '\\' => DIRECTORY_SEPARATOR
+        );
+        $inputFile = strtr($inputFile, $trans);
+        $inputRoot = strtr($inputRoot, $trans);
+
         // Remove the input root from the input filename
         $inputFile = str_replace($inputRoot, '', $inputFile);
 

--- a/tests/Phrozn/Outputter/DefaultOutputterTest.php
+++ b/tests/Phrozn/Outputter/DefaultOutputterTest.php
@@ -53,27 +53,34 @@ class DefaultOutputterTest
 
     public function testStdOutWithResource()
     {
-        $fp = fopen('/tmp/stdout', 'w+');
+        $fp = tmpfile();
         define('STDOUT', $fp);
 
         $outputter = new Outputter();
         $outputter->stdout('sending output', '');
+
+        rewind($fp);
+        $contents = fread($fp, 8096);
+
         fclose($fp);
 
-        $this->assertSame('sending output', trim(file_get_contents('/tmp/stdout')));
+        $this->assertSame('sending output', trim($contents));
     }
 
     public function testStdErrWithResource()
     {
-        $fp = fopen('/tmp/stderr', 'w+');
+        $fp = tmpfile();
         define('STDERR', $fp);
 
         $outputter = new Outputter();
         $outputter->stderr('sending output', '');
 
+        rewind($fp);
+        $contents = fread($fp, 8096);
+
         fclose($fp);
 
-        $this->assertSame('sending output', trim(file_get_contents('/tmp/stderr')));
+        $this->assertSame('sending output', trim($contents));
     }
 
     public function setOutput($out)

--- a/tests/Phrozn/Outputter/PlainOutputterTest.php
+++ b/tests/Phrozn/Outputter/PlainOutputterTest.php
@@ -53,28 +53,34 @@ class PlainOutputterTest
 
     public function testStdOutWithResource()
     {
-        $fp = fopen('/tmp/stdout', 'w+');
+        $fp = tmpfile();
         define('STDOUT', $fp);
 
         $outputter = new Outputter();
         $outputter->stdout('sending output', '');
 
+        rewind($fp);
+        $contents = fread($fp, 8096);
+
         fclose($fp);
 
-        $this->assertSame('sending output', trim(file_get_contents('/tmp/stdout')));
+        $this->assertSame('sending output', trim($contents));
     }
 
     public function testStdErrWithResource()
     {
-        $fp = fopen('/tmp/stderr', 'w+');
+        $fp = tmpfile();
         define('STDERR', $fp);
 
         $outputter = new Outputter();
         $outputter->stderr('sending output', '');
 
+        rewind($fp);
+        $contents = fread($fp, 8096);
+
         fclose($fp);
 
-        $this->assertSame('sending output', trim(file_get_contents('/tmp/stderr')));
+        $this->assertSame('sending output', trim($contents));
     }
 
     public function setOutput($out)

--- a/tests/Phrozn/Outputter/TestOutputterTest.php
+++ b/tests/Phrozn/Outputter/TestOutputterTest.php
@@ -47,28 +47,34 @@ class TestOutputterTest
 
     public function testStdOutWithResource()
     {
-        $fp = fopen('/tmp/stdout', 'w+');
+        $fp = tmpfile();
         define('STDOUT', $fp);
 
         $outputter = new Outputter($this);
         $outputter->stdout('sending output', '');
 
+        rewind($fp);
+        $contents = fread($fp, 8096);
+
         fclose($fp);
 
-        $this->assertSame('sending output', trim(file_get_contents('/tmp/stdout')));
+        $this->assertSame('sending output', trim($contents));
     }
 
     public function testStdErrWithResource()
     {
-        $fp = fopen('/tmp/stderr', 'w+');
+        $fp = tmpfile();
         define('STDERR', $fp);
 
         $outputter = new Outputter($this);
         $outputter->stderr('sending output', '');
 
+        rewind($fp);
+        $contents = fread($fp, 8096);
+
         fclose($fp);
 
-        $this->assertSame('sending output', trim(file_get_contents('/tmp/stderr')));
+        $this->assertSame('sending output', trim($contents));
     }
 
     public function testAssertInLogsFail()

--- a/tests/Phrozn/Runner/CommandLineTest.php
+++ b/tests/Phrozn/Runner/CommandLineTest.php
@@ -31,8 +31,6 @@ use Phrozn\Runner\CommandLine as Runner,
 class CommandLineTest
     extends \PHPUnit_Framework_TestCase
 {
-    const STDOUT = '/tmp/CommandLineTestOut';
-
     private $phr;
     private $outputter;
     private $runner;
@@ -41,7 +39,7 @@ class CommandLineTest
     {
         $this->phr = realpath(__DIR__ . '/../../../bin/phrozn.php');
         $this->outputter = new Outputter($this);
-        $this->fout = fopen(self::STDOUT, 'w+');
+        $this->fout = tmpfile();
         define('STDOUT', $this->fout);
 
         require_once 'Phrozn/Autoloader.php';
@@ -63,7 +61,8 @@ class CommandLineTest
         ));
         $path = dirname(__FILE__) . '/output/phr-help-update.out';
         $original = file_get_contents($path);
-        $rendered = implode("", array_slice(file(self::STDOUT), 1));
+        $rendered = $this->getTempFileContents();
+        $rendered = substr($rendered, strpos($rendered, "\n") + 1);
         $this->assertSame($original, $rendered);
     }
 
@@ -75,7 +74,8 @@ class CommandLineTest
         ));
         $path = dirname(__FILE__) . '/output/phr-help.out';
         $original = file_get_contents($path);
-        $rendered = implode("", array_slice(file(self::STDOUT), 1));
+        $rendered = $this->getTempFileContents();
+        $rendered = substr($rendered, strpos($rendered, "\n") + 1);
         $this->assertSame($original, $rendered);
     }
 
@@ -89,7 +89,7 @@ class CommandLineTest
         ));
         $path = dirname(__FILE__) . '/output/phr-no-params.out';
         $this->assertSame(
-            file_get_contents($path), file_get_contents(self::STDOUT));
+            file_get_contents($path), $this->getTempFileContents());
     }
 
     private function getParseResult($cmd)
@@ -98,5 +98,9 @@ class CommandLineTest
         return $this->parser->parse(count($args), $args);
     }
 
-
+    private function getTempFileContents()
+    {
+        rewind($this->fout);
+        return fread($this->fout, 8096);
+    }
 }


### PR DESCRIPTION
The first 3 commits are required just to get "phr init" + "phr up" to work on windows. I tried to make the changes as unintrusive as possible.

You should really decide whether you want to always use "/" as the directory separator, or always use the DIRECTORY_SEPARATOR constant. Either is good, but mixing them up is what causes problems on windows. For start, I just normalized the separators where needed to make "phr up" work.

In the fourth commit I started fixing tests so they pass on windows. Again, it's linux-specific stuff that fails, see commit messages.

I tested on Travis so you should be OK to merge, but just look over everything in case I messed something up, since I'm not that familiar with the codebase.

Cheers,
Ivan
