### PR TITLE
Issue #86 fixed - PEAR_exception Dependancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "ln -s up.yml configs/commands/update.yml",
             "rm -f bin/phr.php",
             "ln -s phrozn.php bin/phr.php",
-            "chmod +x bin/phrozn.php"
+            "chmod +x bin/phrozn.php",
+            "cp -r vendor/pear/pear_exception/PEAR vendor/pear/console_commandline/Console/CommandLine"
         ]
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
When I install phrozn first time, I got a error with PEAR_exception not exists message even if they installed.

```
Warning: require_once(PEAR/Exception.php): failed to open stream: No such file or directory in /Users/haruair/Repositories/phrozn/vendor/pear/console_commandline/Console/CommandLine/Exception.php on line 28

Fatal error: require_once(): Failed opening required 'PEAR/Exception.php' (include_path='/Users/haruair/Repositories/phrozn/vendor/pear/console_commandline:/Users/haruair/Repositories/phrozn/Phrozn/:/Users/haruair/Repositories/phrozn:/Users/haruair/Repositories/phrozn/bin/../:.:') in /Users/haruair/Repositories/phrozn/vendor/pear/console_commandline/Console/CommandLine/Exception.php on line 28
```

I don't have PEAR in global environment so I added copy method in composer post-install-cmd. This patch can be solved the Issue #86. I think it is not good approach but it works for me. Please check this for non-PEAR-global-environment.
